### PR TITLE
do not unmount keyFilter widget when scanning table

### DIFF
--- a/dyno_viewer/components/screens/query.py
+++ b/dyno_viewer/components/screens/query.py
@@ -164,11 +164,10 @@ class QueryScreen(Screen):
     @on(Switch.Changed, "#scanToggleSwitch")
     def toggle_scan_mode(self, changed: Switch.Changed) -> None:
         self.scan_mode = changed.value
+        key_filter = self.query_one(KeyFilter)
         if changed.value:
-            key_filter = self.query_one(KeyFilter)
             key_filter.display = False
         else:
-            key_filter = self.query_one(KeyFilter)
             key_filter.display = True
 
     # watcher methods

--- a/dyno_viewer/components/screens/query.py
+++ b/dyno_viewer/components/screens/query.py
@@ -166,9 +166,10 @@ class QueryScreen(Screen):
         self.scan_mode = changed.value
         if changed.value:
             key_filter = self.query_one(KeyFilter)
-            key_filter.remove()
+            key_filter.display = False
         else:
-            self.mount(KeyFilter(id="keyFilter"), after="#scanToggle")
+            key_filter = self.query_one(KeyFilter)
+            key_filter.display = True
 
     # watcher methods
 

--- a/tests/unit/screens/test_query_screen.py
+++ b/tests/unit/screens/test_query_screen.py
@@ -278,7 +278,11 @@ async def test_run_query_scan(screen_app, ddb_table, ddb_table_with_data):
             "tab",
         )
 
-        assert not pilot.app.query(KeyFilter)
+        key_filter = pilot.app.query_one(KeyFilter)
+
+        assert key_filter
+        assert not key_filter.display
+        
         await assert_filter_one(pilot, "test", "test1")
 
         # send run query message back to root app
@@ -311,7 +315,10 @@ async def test_run_query_scan_no_filters(screen_app, ddb_table, ddb_table_with_d
             "tab",
         )
 
-        assert not pilot.app.query(KeyFilter)
+        key_filter = pilot.app.query_one(KeyFilter)
+
+        assert key_filter
+        assert not key_filter.display
 
         # send run query message back to root app
         await type_commands(["tab", "r"], pilot)


### PR DESCRIPTION
when reenabling query mode form doing a scan it was causing  the key names e.g primary key to be lost in the keyFilter widget